### PR TITLE
[iOS] Adding optional boolean parameter to unlockOrientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ The __screen.orientation__ property will not update when the phone is [rotated 1
 
 ## iOS Notes
 
-An optional parameter can be passed to screen.unlockOrientation:
+
+The iOS version is a combination of the cordova JS callback _window.shouldRotateToOrientation_ and the workaround to recheck the orientation as implemented in https://github.com/Adlotto/cordova-plugin-recheck-screen-orientation.
+
+__If you have a custom implementation of the _window.shouldRotateToOrientation_ it will have to be removed for the plugin to function as expected.__
+
+
+An optional parameter can be passed to _screen.unlockOrientation_:
 ```js
 // default behaviour
 screen.unlockOrientation() 
@@ -111,11 +117,6 @@ screen.unlockOrientation()
 // force to unlock all possible orientation modes
 screen.unlockOrientation(true) 
 ```
-
-
-The iOS version is a combination of the cordova JS callback _window.shouldRotateToOrientation_ and the workaround to recheck the orientation as implemented in https://github.com/Adlotto/cordova-plugin-recheck-screen-orientation.
-
-__If you have a custom implementation of the _window.shouldRotateToOrientation_ it will have to be removed for the plugin to function as expected.__
 
 #### iOS6
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ The __screen.orientation__ property will not update when the phone is [rotated 1
 
 ## iOS Notes
 
+An optional parameter can be passed to screen.unlockOrientation:
+```js
+// default behaviour
+screen.unlockOrientation() 
+
+// force to unlock all possible orientation modes
+screen.unlockOrientation(true) 
+```
+
+
 The iOS version is a combination of the cordova JS callback _window.shouldRotateToOrientation_ and the workaround to recheck the orientation as implemented in https://github.com/Adlotto/cordova-plugin-recheck-screen-orientation.
 
 __If you have a custom implementation of the _window.shouldRotateToOrientation_ it will have to be removed for the plugin to function as expected.__

--- a/src/ios/YoikScreenOrientation.m
+++ b/src/ios/YoikScreenOrientation.m
@@ -36,8 +36,22 @@
         NSString* orientationIn = [arguments objectAtIndex:1];
 
         if ([orientationIn isEqual: @"unlocked"]) {
-            [(CDVViewController*)self.viewController updateSupportedOrientations:self.originalSupportedOrientations];
-            self.originalSupportedOrientations = nil;
+
+            NSNumber* allAvailable = [arguments objectAtIndex:2];
+
+            if( [allAvailable isEqualToNumber: [NSNumber numberWithInteger:1]] ){
+
+                [(CDVViewController*)self.viewController updateSupportedOrientations: @[
+                                                             [NSNumber numberWithInt:UIDeviceOrientationPortrait],
+                                                             [NSNumber numberWithInt:UIDeviceOrientationPortraitUpsideDown],
+                                                             [NSNumber numberWithInt:UIDeviceOrientationLandscapeLeft],
+                                                             [NSNumber numberWithInt:UIDeviceOrientationLandscapeRight]]];
+
+            }
+            else{
+                [(CDVViewController*)self.viewController updateSupportedOrientations:self.originalSupportedOrientations];
+                self.originalSupportedOrientations = nil;
+            }
             return;
         }
         

--- a/www/screenorientation.ios.js
+++ b/www/screenorientation.ios.js
@@ -32,7 +32,7 @@ var exec = require('cordova/exec'),
         'default': [-90,90,0,180]
     };
 
-screenOrientation.setOrientation = function(orientation) {
+screenOrientation.setOrientation = function(orientation, opt) {
     iosOrientation = orientation;
 
     var success = function(res) {
@@ -44,7 +44,7 @@ screenOrientation.setOrientation = function(orientation) {
         }
     };
 
-    exec(success, null, "YoikScreenOrientation", "screenOrientation", ['set', orientation]);
+    exec(success, null, "YoikScreenOrientation", "screenOrientation", ['set', orientation, !!opt]);
 };
 
 module.exports = screenOrientation;

--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -57,9 +57,9 @@ function addScreenOrientationApi(screenObject) {
         screenOrientation.setOrientation(orientation);
     };
 
-    screenObject.unlockOrientation = function() {
+    screenObject.unlockOrientation = function(opt) {
         screenOrientation.currOrientation = screenObject.orientation = 'unlocked';
-        screenOrientation.setOrientation('unlocked');
+        screenOrientation.setOrientation('unlocked', opt);
     };
 }
 


### PR DESCRIPTION
Given.
Initially the app is supposed to be running in landscape mode.
There is a need to unlock portrait mode at some point.

Problem.
Configuring the app running in all orientation modes and calling `screen.setOrientation('landscape')` at launch time creates an undesired effect.
When launching the app by holding device vertically a splash screen appears at first in portrait mode and then jumps to landscape mode creating an undesired 'jerking' effect.

Solution.
Configure the app running in landscape mode only (Xcode > General > Device Orientation > Landscape).
When there is a need to unlock portrait mode then call `screen.unlockOrientation(true)` passing `true` as a parameter.
Calling `screen.unlockOrientation(true)` overwrites the default settings and unlocks all available orientation modes.
